### PR TITLE
Docker compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # docker run -v `pwd`:/usr/src/app -it --rm wloche/jira-tools:latest
 
 # https://nodejs.org/en/docs/guides/nodejs-docker-webapp/
-FROM node:16
+FROM node:16-slim
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/classes/config-dist.js
+++ b/classes/config-dist.js
@@ -8,9 +8,9 @@
 
 const Config = {
     /* ###### Parameters to be updated ###### */
-    USER: '##USER##',
-    PASSWORD: '##PASSWORD##',
-    DOMAIN_NAME: 'https://##your-jira-server##',
+    USER: process.env.JIRA_USERNAME,
+    PASSWORD: process.env.JIRA_PASSWORD,
+    DOMAIN_NAME: process.env.JIRA_URL,
     BASE_URL_REST_V2: '/jira/rest/api/2/',
     // f.e. Matches SPA Sprint 6
     SPRINT_REG_EXP: /Sprint \d+/i,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.7'
+
+services:
+  jira:
+    build: .
+    environment:
+      JIRA_USERNAME: ${JIRA_USERNAME}
+      JIRA_PASSWORD: ${JIRA_PASSWORD}
+      JIRA_URL: ${JIRA_URL}
+    volumes:
+      - "./:/usr/src/app/"
+    command: >
+     sh -c "
+      npm install &&
+      node sprints-stats.js
+     "

--- a/documentation/sprints-stats/sprints-stats.md
+++ b/documentation/sprints-stats/sprints-stats.md
@@ -54,7 +54,8 @@ $ git clone https://github.com/wloche/jira-tools.git
 
 ## `config.js`
 1. Copy `classes/config-dist.js` and renamed it to `classes/config.js`
-2. Replace the values with your credentials and Jira domain name.
+2. Replace the values with your credentials and Jira domain name. Or set a `JIRA_URL` environment variable to your Jira organization's URL,
+   set a `JIRA_USERNAME` to your Jira username, and finally set `JIRA_PASSWORD` to your Jira password or API token (see below)
 3. If you are using a token: just put it in the `PASSWORD`. 🔗 [API Tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
 
 ```javascript
@@ -114,15 +115,11 @@ const teams = [ ];
 ```
 
 # Run
+Make sure your local enviroment has `JIRA_URL`, `JIRA_USERNAME` and `JIRA_PASSWORD` set appropriately first, then
+
 ## Docker
 ```shell
-# Build the image (once)
-docker build . -t wloche/jira-tools:latest
-# Install the node modules (once)
-docker run -v `pwd`:/usr/src/app -it --rm wloche/jira-tools:latest npm install
-
-# Run the scrip (each time you need!!)
-docker run -v `pwd`:/usr/src/app -it --rm wloche/jira-tools:latest
+docker-compose up
 ```
 
 ## Locally

--- a/documentation/sprints-stats/sprints-stats.md
+++ b/documentation/sprints-stats/sprints-stats.md
@@ -119,7 +119,7 @@ Make sure your local enviroment has `JIRA_URL`, `JIRA_USERNAME` and `JIRA_PASSWO
 
 ## Docker
 ```shell
-docker-compose up
+docker-compose up --no-log-prefix
 ```
 
 ## Locally


### PR DESCRIPTION
This PR makes the following changes

* Updates the container image to `node:16-slim` to save space/download times
* Pulls your Jira Username, password, and URL from the environment 
* Adds support to run via docker-compose so you just need to run `docker-compose up` 
* Updates docs